### PR TITLE
Fixed issue when subscription lambda exits after ticket creation

### DIFF
--- a/src/main/java/io/github/ashleytaylor/graphql/lambda/example/TicketUpdate.java
+++ b/src/main/java/io/github/ashleytaylor/graphql/lambda/example/TicketUpdate.java
@@ -51,6 +51,10 @@ public class TicketUpdate extends LambdaSubscriptionSource<DynamodbEvent, Ticket
 				}
 				var node = toJsonNode(image);
 				try {
+					// Does not exist when a new ticket is created
+					if (node.get("item") == null) {
+						continue;
+					}
 					var ticket = SchemaBuilder.MAPPER.treeToValue(node.get("item"), Ticket.class);
 					String organisationId = record.getDynamodb().getNewImage().get("organisationId").getS();
 					process(new WrapperTicket(organisationId, ticket)).get();


### PR DESCRIPTION
DynamodbEvent event seems to not have an "item" property after creating a ticket. A subsequent event then comes in that has changes to the created ticket and that time has "item" property. Without these changes it just hangs.

After a quick test sync now works consistently even after creating/deleting a ticket.

This is obviously a little hacky and doesn't get to the bottom of the fundamental issue. I hope it at-least helps.

